### PR TITLE
Make mobile menu full width

### DIFF
--- a/script.js
+++ b/script.js
@@ -161,8 +161,9 @@ document.addEventListener('DOMContentLoaded', function() {
                         .nav {
                             position: absolute;
                             top: 100%;
-                            left: 0;
-                            right: 0;
+                            left: 50%;
+                            transform: translateX(-50%);
+                            width: 100vw;
                             background-color: white;
                             flex-direction: column;
                             box-shadow: var(--shadow);
@@ -171,13 +172,13 @@ document.addEventListener('DOMContentLoaded', function() {
                             border-radius: 0 0 12px 12px;
                             z-index: 20;
                             opacity: 0;
-                            transform: translateY(-10px);
+                            transform: translateX(-50%) translateY(-10px);
                             transition: opacity 0.2s ease, transform 0.2s ease;
                         }
                         .nav.mobile-nav-open {
                             display: flex !important;
                             opacity: 1;
-                            transform: translateY(0);
+                            transform: translateX(-50%) translateY(0);
                         }
                         .mobile-menu-btn {
                             display: block !important;


### PR DESCRIPTION
Make the mobile menu full width by positioning it relative to the viewport instead of a padded container.

The menu was previously constrained by the padding of its parent container, preventing it from achieving full width. This change uses `width: 100vw` and horizontal centering (`left: 50%; transform: translateX(-50%);`) to ensure it spans the entire viewport width.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb4d9496-b873-4d3e-bf67-000b668e66b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb4d9496-b873-4d3e-bf67-000b668e66b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>